### PR TITLE
Add compatibility with g++ compiler and C++11 standard

### DIFF
--- a/src/ini.c
+++ b/src/ini.c
@@ -179,7 +179,7 @@ ini_t* ini_load(const char *filename) {
   int n, sz;
 
   /* Init ini struct */
-  ini = malloc(sizeof(*ini));
+  ini = (ini_t*)malloc(sizeof(*ini));
   if (!ini) {
     goto fail;
   }
@@ -197,7 +197,7 @@ ini_t* ini_load(const char *filename) {
   rewind(fp);
 
   /* Load file content into memory, null terminate, init end var */
-  ini->data = malloc(sz + 1);
+  ini->data = (char*)malloc(sz + 1);
   ini->data[sz] = '\0';
   ini->end = ini->data  + sz;
   n = fread(ini->data, 1, sz, fp);
@@ -226,7 +226,7 @@ void ini_free(ini_t *ini) {
 
 
 const char* ini_get(ini_t *ini, const char *section, const char *key) {
-  char *current_section = "";
+  char *current_section;
   char *val;
   char *p = ini->data;
 


### PR DESCRIPTION
It's not possible to use malloc without a cast as g++ treats it as an
invalid conversion. Initializing a char pointer with an empty string
will also issue a warning, so current_section char pointer must not be
initialized.